### PR TITLE
Use relative location of geocms gems.

### DIFF
--- a/api/app/controllers/geocms/api/v1/data_sources_controller.rb
+++ b/api/app/controllers/geocms/api/v1/data_sources_controller.rb
@@ -1,5 +1,5 @@
-require File.join(Rails.root, "../geocms/core/app/services/geocms/OGC/client.rb")
 module Geocms
+  require "#{File.dirname(__FILE__)}/../../../../../../core/app/services/geocms/OGC/client"
   class Api::V1::DataSourcesController < Api::V1::BaseController
     
 


### PR DESCRIPTION
Hi,

by using ``File.join(Rails.root, "../geocms/core...`` , api data_sources_controller.rb assumes
geocms gems are in a sibling directory of the app directory. This prevents the app from beeing
named geocms, but most importantly, you get an error when geocms gems are installed somewhere
else : 
```
Exiting
/app/rails/myapp/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require': No such file to load -- /app/rails/myapp/../geocms/core/app/services/geocms/OGC/client (LoadError)
	from /app/rails/myapp/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
...
```
I propose to make another assumption instead : core and and api are always sibling, wherever
they are.